### PR TITLE
Fix broken Ponder build dependency and add PlayerRecord/ExperienceCalculator unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- Unit tests for `PlayerRecord` (skill levels, experience, overall level, save/load) and `ExperienceCalculator`
+
 ## [2.4.1]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Unit tests for `PlayerRecord` (skill levels, experience, overall level, save/load) and `ExperienceCalculator`
 
+### Fixed
+- Broken `Ponder` dependency coordinates in `pom.xml` that made the project (and CI) fail to build: the pinned tag `v0.14-alpha-2` no longer exists upstream, and the `groupId`/`artifactId` combination was never resolvable via jitpack for this repository
+
 ## [2.4.1]
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -106,9 +106,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>preponderous</groupId>
-            <artifactId>ponder</artifactId>
-            <version>v0.14-alpha-2</version>
+            <groupId>com.github.Dans-Plugins</groupId>
+            <artifactId>Ponder</artifactId>
+            <version>v0.14</version>
         </dependency>
         <dependency>
             <groupId>com.github.cryptomorin</groupId>

--- a/src/test/java/dansplugins/simpleskills/experience/ExperienceCalculatorTest.java
+++ b/src/test/java/dansplugins/simpleskills/experience/ExperienceCalculatorTest.java
@@ -1,0 +1,58 @@
+package dansplugins.simpleskills.experience;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ExperienceCalculatorTest {
+
+    private ExperienceCalculator experienceCalculator;
+
+    @Before
+    public void setUp() {
+        experienceCalculator = new ExperienceCalculator();
+    }
+
+    @Test
+    public void getExperienceRequiredForLevelUp_returnsZero_whenCurrentLevelIsZero() {
+        int result = experienceCalculator.getExperienceRequiredForLevelUp(0, 100, 1.2);
+
+        assertEquals(0, result);
+    }
+
+    @Test
+    public void getExperienceRequiredForLevelUp_returnsBaseRequirement_whenCurrentLevelIsOne() {
+        int result = experienceCalculator.getExperienceRequiredForLevelUp(1, 50, 1.2);
+
+        assertEquals(50, result);
+    }
+
+    @Test
+    public void getExperienceRequiredForLevelUp_returnsBaseRequirement_whenIncreaseFactorIsZero() {
+        int result = experienceCalculator.getExperienceRequiredForLevelUp(25, 10, 0.0);
+
+        assertEquals(10, result);
+    }
+
+    @Test
+    public void getExperienceRequiredForLevelUp_scalesWithLevelAndFactor() {
+        int currentLevel = 5;
+        int baseExperienceRequirement = 10;
+        double experienceIncreaseFactor = 1.5;
+
+        int result = experienceCalculator.getExperienceRequiredForLevelUp(
+                currentLevel, baseExperienceRequirement, experienceIncreaseFactor);
+
+        int expected = (int) (baseExperienceRequirement * Math.pow(currentLevel, experienceIncreaseFactor));
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void getExperienceRequiredForLevelUp_truncatesFractionalResultTowardZero() {
+        // base=3, level=2, factor=1.5 -> 3 * 2^1.5 = 8.485..., truncated to 8
+        int result = experienceCalculator.getExperienceRequiredForLevelUp(2, 3, 1.5);
+
+        assertEquals(8, result);
+    }
+}

--- a/src/test/java/dansplugins/simpleskills/playerrecord/PlayerRecordTest.java
+++ b/src/test/java/dansplugins/simpleskills/playerrecord/PlayerRecordTest.java
@@ -1,0 +1,205 @@
+package dansplugins.simpleskills.playerrecord;
+
+import dansplugins.simpleskills.config.ConfigService;
+import dansplugins.simpleskills.experience.ExperienceCalculator;
+import dansplugins.simpleskills.logging.Log;
+import dansplugins.simpleskills.message.MessageService;
+import dansplugins.simpleskills.skill.SkillRepository;
+import dansplugins.simpleskills.skill.abs.AbstractSkill;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Characterizes {@link PlayerRecord}'s current behavior for the pure bookkeeping paths
+ * (skill levels, experience, overall level, save/load). Paths that reach a live
+ * {@code Bukkit.getPlayer(...)} call (auto-learning an unknown skill via
+ * {@code getSkillLevel(id, true)} and leveling up) are intentionally not exercised here:
+ * mockito-core (without mockito-inline) cannot stub Bukkit's static accessors, and the
+ * project pins Mockito 3.12.4 for JDK 21 compatibility reasons, so those branches are
+ * left for the manual Testcontainer smoke harness.
+ */
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class PlayerRecordTest {
+
+    private static final UUID PLAYER_UUID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+
+    @Mock
+    private SkillRepository skillRepository;
+    @Mock
+    private MessageService messageService;
+    @Mock
+    private ConfigService configService;
+    @Mock
+    private ExperienceCalculator experienceCalculator;
+    @Mock
+    private Log log;
+    @Mock
+    private FileConfiguration fileConfiguration;
+
+    private PlayerRecord record;
+
+    @Before
+    public void setUp() {
+        when(configService.getConfig()).thenReturn(fileConfiguration);
+        when(fileConfiguration.getInt("defaultMaxLevel")).thenReturn(100);
+
+        record = new PlayerRecord(skillRepository, messageService, configService, experienceCalculator, log, PLAYER_UUID);
+    }
+
+    private AbstractSkill mockSkill(int id, boolean active) {
+        AbstractSkill skill = mock(AbstractSkill.class);
+        when(skill.getId()).thenReturn(id);
+        when(skill.isActive()).thenReturn(active);
+        return skill;
+    }
+
+    @Test
+    public void getSkillLevel_returnsNegativeOne_whenUnknownAndLearnFlagFalse() {
+        assertEquals(-1, record.getSkillLevel(1, false));
+    }
+
+    @Test
+    public void getSkillLevel_returnsStoredLevel_whenKnown() {
+        record.setSkillLevel(1, 5);
+
+        assertEquals(5, record.getSkillLevel(1, true));
+        assertEquals(5, record.getSkillLevel(1, false));
+    }
+
+    @Test
+    public void setSkillLevel_replacesExistingEntry() {
+        record.setSkillLevel(1, 5);
+        record.setSkillLevel(1, 9);
+
+        assertEquals(9, record.getSkillLevel(1, false));
+    }
+
+    @Test
+    public void incrementSkillLevel_incrementsPreseededLevel() {
+        record.setSkillLevel(1, 0);
+
+        record.incrementSkillLevel(1);
+
+        assertEquals(1, record.getSkillLevel(1, false));
+    }
+
+    @Test
+    public void getExperience_defaultsToZero_andStoresValue() {
+        assertEquals(0, record.getExperience(2));
+
+        record.setExperience(2, 7);
+
+        assertEquals(7, record.getExperience(2));
+    }
+
+    @Test
+    public void getKnownSkills_and_isKnown_reflectStoredSkillLevels() {
+        AbstractSkill skill = mockSkill(3, true);
+        record.setSkillLevel(3, 0);
+
+        assertTrue(record.getKnownSkills().contains(3));
+        assertTrue(record.isKnown(skill));
+    }
+
+    @Test
+    public void isKnown_returnsFalse_whenSkillNeverSeeded() {
+        AbstractSkill skill = mockSkill(4, true);
+
+        assertFalse(record.isKnown(skill));
+    }
+
+    @Test
+    public void getOverallSkillLevel_sumsOnlyActiveKnownSkills() {
+        AbstractSkill activeSkill = mockSkill(1, true);
+        AbstractSkill inactiveSkill = mockSkill(2, false);
+        when(skillRepository.getSkill(1)).thenReturn(activeSkill);
+        when(skillRepository.getSkill(2)).thenReturn(inactiveSkill);
+        // skill 3 is known locally but no longer exists in the repository (e.g. removed)
+        when(skillRepository.getSkill(3)).thenReturn(null);
+
+        record.setSkillLevel(1, 5);
+        record.setSkillLevel(2, 10);
+        record.setSkillLevel(3, 7);
+
+        assertEquals(5, record.getOverallSkillLevel());
+    }
+
+    @Test
+    public void incrementExperience_incrementsExperience_evenWhenSkillUnknownToRepository() {
+        when(skillRepository.getSkill(5)).thenReturn(null);
+
+        record.incrementExperience(5);
+
+        assertEquals(1, record.getExperience(5));
+    }
+
+    @Test
+    public void incrementExperience_doesNotLevelUp_whenBelowRequiredExperience() {
+        AbstractSkill skill = mockSkill(6, true);
+        when(skillRepository.getSkill(6)).thenReturn(skill);
+        when(experienceCalculator.getExperienceRequiredForLevelUp(anyInt(), anyInt(), anyDouble())).thenReturn(50);
+        record.setSkillLevel(6, 0);
+
+        record.incrementExperience(6);
+
+        assertEquals(1, record.getExperience(6));
+        assertEquals(0, record.getSkillLevel(6, false));
+    }
+
+    @Test
+    public void incrementExperience_skipsLevelUpCheck_whenAlreadyAtMaxLevel() {
+        AbstractSkill skill = mockSkill(8, true);
+        when(skillRepository.getSkill(8)).thenReturn(skill);
+        when(fileConfiguration.getInt("defaultMaxLevel")).thenReturn(5);
+        record.setSkillLevel(8, 5);
+
+        record.incrementExperience(8);
+
+        assertEquals(1, record.getExperience(8));
+        assertEquals(5, record.getSkillLevel(8, false));
+    }
+
+    @Test
+    public void checkForLevelUp_leavesLevelAndExperienceUnchanged_whenBelowThreshold() {
+        AbstractSkill skill = mockSkill(7, true);
+        when(skillRepository.getSkill(7)).thenReturn(skill);
+        when(experienceCalculator.getExperienceRequiredForLevelUp(anyInt(), anyInt(), anyDouble())).thenReturn(10);
+        record.setSkillLevel(7, 2);
+        record.setExperience(7, 3);
+
+        record.checkForLevelUp(7);
+
+        assertEquals(2, record.getSkillLevel(7, false));
+        assertEquals(3, record.getExperience(7));
+    }
+
+    @Test
+    public void saveAndLoad_roundTripsPlayerUuidLevelsAndExperience() {
+        record.setSkillLevel(1, 5);
+        record.setSkillLevel(2, 1);
+        record.setExperience(1, 7);
+
+        Map<String, String> saved = record.save();
+        PlayerRecord loaded = new PlayerRecord(saved, skillRepository, messageService, configService, experienceCalculator, log);
+
+        assertEquals(record.getPlayerUUID(), loaded.getPlayerUUID());
+        assertEquals(record.getSkillLevels(), loaded.getSkillLevels());
+        assertEquals(new HashMap<>(record.getExperience()), new HashMap<>(loaded.getExperience()));
+    }
+}


### PR DESCRIPTION
<!-- gardener-tend-dispatch -->

## Summary
This PR does two coupled things — the second needed the first to actually verify in CI:

1. **Fixes the build.** `pom.xml` pinned `preponderous:ponder:v0.14-alpha-2`, which is broken two ways: that tag doesn't exist in [Dans-Plugins/Ponder](https://github.com/Dans-Plugins/Ponder) anymore, and the `groupId:artifactId` casing (`preponderous:ponder`) was never resolvable via jitpack (Ponder's own `pom.xml` declares `preponderous:Ponder`, and jitpack in practice only serves it under `com.github.Dans-Plugins:Ponder`). This has been breaking `mvn compile`/CI on `main` for everyone (confirmed: the last CI run on `main` failed with the same error, and none of the other 8 open PRs in this repo have any CI checks reported at all). Switches to `com.github.Dans-Plugins:Ponder:v0.14` — the nearest existing tag whose package layout matches this project's existing imports exactly, so no source changes were needed. Related to #116 but does **not** close it — see the comment I left there on why a true "latest release" upgrade is a separate, larger, breaking migration.
2. **Bootstraps this repo's first `src/test` tests**, despite JUnit 4 + Mockito already being wired into `pom.xml` with nothing using them:
   - `PlayerRecordTest`: skill-level get/set, experience get/set, `getKnownSkills`/`isKnown`, `getOverallSkillLevel` (filters inactive/removed skills), `incrementExperience`'s no-level-up and max-level-skip branches, `checkForLevelUp` below-threshold behavior, and a `save()`/`load()` round-trip.
   - `ExperienceCalculatorTest`: the `getExperienceRequiredForLevelUp` formula (level 0, level 1, zero factor, general scaling, int-truncation).
   - No production code behavior was changed by the test PR itself — this is characterization coverage (Stage B of the dev loop: unit-test expansion).

**Known gap, left uncovered on purpose:** `PlayerRecord.learnSkill(...)`/`levelUp(...)` call `Bukkit.getPlayer(...)` (a static Bukkit accessor). The project pins `mockito-core:3.12.4` with no `mockito-inline`, so stubbing that static call isn't available without adding a new test dependency — left out of scope here. Auto-learning an unknown skill and the leveling-up branch of `checkForLevelUp` remain covered only by the manual `.testcontainer` Spigot smoke harness.

## Test plan
- [x] `mvn clean package` (the exact command CI runs) — green locally after the dependency fix: `BUILD SUCCESS`, all 18 new tests pass.
- [x] `mvn test` — `Tests run: 18, Failures: 0, Errors: 0, Skipped: 0`.
- [x] Verified via a scratch clone of the Ponder repo at both `v0.14` and `v0.15-alpha-2` that `v0.14`'s package layout matches this project's imports exactly, while `v0.15-alpha-2` renames packages (documented in the commit message and issue #116 comment).

Related: #116 (not closed — see above)

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
