### PR TITLE
Prevent Silk Touch block-skill experience farming exploit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Broken `Ponder` dependency coordinates in `pom.xml` that made the project (and CI) fail to build: the pinned tag `v0.14-alpha-2` no longer exists upstream, and the `groupId`/`artifactId` combination was never resolvable via jitpack for this repository
+- Silk Touch mining/quarrying/digging/woodcutting/floriculture/pyromaniac experience farming exploit: breaking a block that a player placed (e.g. a Silk Touch-harvested ore placed back down) no longer grants skill experience or rewards
 
 ## [2.4.1]
 

--- a/src/main/java/dansplugins/simpleskills/SimpleSkills.java
+++ b/src/main/java/dansplugins/simpleskills/SimpleSkills.java
@@ -3,6 +3,7 @@ package dansplugins.simpleskills;
 import dansplugins.simpleskills.bstats.Metrics;
 import dansplugins.simpleskills.commands.*;
 import dansplugins.simpleskills.commands.tab.TabCommand;
+import dansplugins.simpleskills.listeners.PlacedBlockListener;
 import dansplugins.simpleskills.listeners.PlayerJoinEventListener;
 import dansplugins.simpleskills.playerrecord.PlayerRecordRepository;
 import dansplugins.simpleskills.config.ConfigService;
@@ -44,6 +45,7 @@ public class SimpleSkills extends JavaPlugin {
     private final StorageService storageService = new StorageService(playerRecordRepository, skillRepository, messageService, configService, experienceCalculator, log);
     private final ChanceCalculator chanceCalculator = new ChanceCalculator(playerRecordRepository, configService, skillRepository, messageService, experienceCalculator, log);
     private final PlayerJoinEventListener playerJoinEventListener = new PlayerJoinEventListener(playerRecordRepository, log);
+    private final PlacedBlockListener placedBlockListener = new PlacedBlockListener(this);
 
 
     /**
@@ -169,6 +171,9 @@ public class SimpleSkills extends JavaPlugin {
         }
 
         Bukkit.getPluginManager().registerEvents(playerJoinEventListener, this);
+        // Registered after skills so its BlockBreakEvent cleanup (also MONITOR priority) runs
+        // after the skills' own handlers have checked PlacedBlockListener.isPlayerPlaced().
+        Bukkit.getPluginManager().registerEvents(placedBlockListener, this);
     }
 
     private void initializeCommandService() {

--- a/src/main/java/dansplugins/simpleskills/listeners/PlacedBlockListener.java
+++ b/src/main/java/dansplugins/simpleskills/listeners/PlacedBlockListener.java
@@ -1,0 +1,52 @@
+package dansplugins.simpleskills.listeners;
+
+import dansplugins.simpleskills.SimpleSkills;
+import org.bukkit.block.Block;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.metadata.FixedMetadataValue;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Tracks which blocks were placed by a player so that block-based skills can refuse to grant
+ * experience for them, closing the exploit where a Silk Touch-harvested ore (or other
+ * skill-tracked block) is placed back down and re-mined repeatedly for infinite experience.
+ * <p>
+ * Must be registered <em>after</em> the skills in {@code SimpleSkills#registerEventListeners()}
+ * so that {@link #onBlockBreak(BlockBreakEvent)} (which cleans up the tracking metadata) runs
+ * after the skills' own {@code MONITOR}-priority handlers have had a chance to check it.
+ * </p>
+ */
+public class PlacedBlockListener implements Listener {
+    private static final String METADATA_KEY = "simpleskills-player-placed";
+
+    private final SimpleSkills simpleSkills;
+
+    public PlacedBlockListener(@NotNull SimpleSkills simpleSkills) {
+        this.simpleSkills = simpleSkills;
+    }
+
+    /**
+     * @param block the block to check.
+     * @return {@code true} if this block was placed by a player and has not yet been broken.
+     */
+    public static boolean isPlayerPlaced(@NotNull Block block) {
+        return block.hasMetadata(METADATA_KEY);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onBlockPlace(@NotNull BlockPlaceEvent event) {
+        event.getBlock().setMetadata(METADATA_KEY, new FixedMetadataValue(simpleSkills, true));
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onBlockBreak(@NotNull BlockBreakEvent event) {
+        final Block block = event.getBlock();
+        if (block.hasMetadata(METADATA_KEY)) {
+            block.removeMetadata(METADATA_KEY, simpleSkills);
+        }
+    }
+}

--- a/src/main/java/dansplugins/simpleskills/skill/abs/AbstractBlockSkill.java
+++ b/src/main/java/dansplugins/simpleskills/skill/abs/AbstractBlockSkill.java
@@ -1,6 +1,7 @@
 package dansplugins.simpleskills.skill.abs;
 
 import dansplugins.simpleskills.SimpleSkills;
+import dansplugins.simpleskills.listeners.PlacedBlockListener;
 import dansplugins.simpleskills.playerrecord.PlayerRecordRepository;
 import dansplugins.simpleskills.config.ConfigService;
 import dansplugins.simpleskills.message.MessageService;
@@ -57,6 +58,10 @@ public abstract class AbstractBlockSkill extends AbstractSkill {
         log.debug("Block skill type is valid for this event.");
         if (!isValidMaterial(event.getBlock().getType())) return;
         log.debug("Block material is valid for this skill.");
+        if (PlacedBlockListener.isPlayerPlaced(event.getBlock())) {
+            log.debug("Block was placed by a player; skipping skill experience to prevent farming exploits.");
+            return;
+        }
         incrementExperience(event.getPlayer());
         log.debug("Incremented experience for player: " + event.getPlayer().getName());
         executeReward(event.getPlayer(), event.getBlock(), event);

--- a/src/test/java/dansplugins/simpleskills/listeners/PlacedBlockListenerTest.java
+++ b/src/test/java/dansplugins/simpleskills/listeners/PlacedBlockListenerTest.java
@@ -1,0 +1,101 @@
+package dansplugins.simpleskills.listeners;
+
+import dansplugins.simpleskills.SimpleSkills;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.metadata.MetadataValue;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Characterizes {@link PlacedBlockListener}'s tracking of player-placed blocks, which
+ * {@link dansplugins.simpleskills.skill.abs.AbstractBlockSkill} consults to prevent the
+ * place-then-rebreak experience farming exploit (e.g. Silk Touch-harvested ore).
+ * <p>
+ * Real {@link BlockBreakEvent}/{@link BlockPlaceEvent} instances are constructed (rather than
+ * mocked) because {@code BlockEvent#getBlock()} is {@code final} and mockito-core (without
+ * mockito-inline) cannot stub final methods.
+ * </p>
+ */
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class PlacedBlockListenerTest {
+    private static final String METADATA_KEY = "simpleskills-player-placed";
+
+    @Mock
+    private SimpleSkills simpleSkills;
+
+    @Mock
+    private Block block;
+
+    @Mock
+    private Player player;
+
+    private PlacedBlockListener placedBlockListener;
+
+    @Before
+    public void setUp() {
+        placedBlockListener = new PlacedBlockListener(simpleSkills);
+    }
+
+    @Test
+    public void onBlockPlace_marksTheBlockAsPlayerPlaced() {
+        final BlockPlaceEvent event = new BlockPlaceEvent(block, mock(BlockState.class), block,
+                mock(ItemStack.class), player, true, EquipmentSlot.HAND);
+
+        placedBlockListener.onBlockPlace(event);
+
+        final ArgumentCaptor<MetadataValue> valueCaptor = ArgumentCaptor.forClass(MetadataValue.class);
+        verify(block).setMetadata(eq(METADATA_KEY), valueCaptor.capture());
+        assertEquals(simpleSkills, valueCaptor.getValue().getOwningPlugin());
+        assertTrue(valueCaptor.getValue().asBoolean());
+    }
+
+    @Test
+    public void onBlockBreak_removesTrackingMetadata_whenBlockWasPlayerPlaced() {
+        when(block.hasMetadata(METADATA_KEY)).thenReturn(true);
+        final BlockBreakEvent event = new BlockBreakEvent(block, player);
+
+        placedBlockListener.onBlockBreak(event);
+
+        verify(block).removeMetadata(METADATA_KEY, simpleSkills);
+    }
+
+    @Test
+    public void onBlockBreak_doesNothing_whenBlockWasNotPlayerPlaced() {
+        when(block.hasMetadata(METADATA_KEY)).thenReturn(false);
+        final BlockBreakEvent event = new BlockBreakEvent(block, player);
+
+        placedBlockListener.onBlockBreak(event);
+
+        verify(block, never()).removeMetadata(anyString(), any());
+    }
+
+    @Test
+    public void isPlayerPlaced_reflectsWhetherTheMetadataIsPresent() {
+        when(block.hasMetadata(METADATA_KEY)).thenReturn(true);
+        assertTrue(PlacedBlockListener.isPlayerPlaced(block));
+
+        when(block.hasMetadata(METADATA_KEY)).thenReturn(false);
+        assertFalse(PlacedBlockListener.isPlayerPlaced(block));
+    }
+}

--- a/src/test/java/dansplugins/simpleskills/skill/abs/AbstractBlockSkillTest.java
+++ b/src/test/java/dansplugins/simpleskills/skill/abs/AbstractBlockSkillTest.java
@@ -1,0 +1,148 @@
+package dansplugins.simpleskills.skill.abs;
+
+import dansplugins.simpleskills.SimpleSkills;
+import dansplugins.simpleskills.config.ConfigService;
+import dansplugins.simpleskills.logging.Log;
+import dansplugins.simpleskills.message.MessageService;
+import dansplugins.simpleskills.playerrecord.PlayerRecord;
+import dansplugins.simpleskills.playerrecord.PlayerRecordRepository;
+import org.bukkit.GameMode;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.UUID;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Characterizes {@link AbstractBlockSkill#handle(BlockBreakEvent)}'s player-placed-block
+ * check, which prevents the exploit of placing a Silk Touch-harvested (or otherwise
+ * obtained) skill-tracked block back down and re-mining it for repeated experience.
+ */
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class AbstractBlockSkillTest {
+
+    @Mock
+    private ConfigService configService;
+    @Mock
+    private Log log;
+    @Mock
+    private PlayerRecordRepository playerRecordRepository;
+    @Mock
+    private SimpleSkills simpleSkills;
+    @Mock
+    private MessageService messageService;
+    @Mock
+    private FileConfiguration fileConfiguration;
+    @Mock
+    private Player player;
+    @Mock
+    private Block block;
+    @Mock
+    private PlayerRecord playerRecord;
+
+    private TestBlockSkill skill;
+
+    @Before
+    public void setUp() {
+        when(configService.getConfig()).thenReturn(fileConfiguration);
+        when(fileConfiguration.getBoolean(anyString(), anyBoolean())).thenReturn(true);
+        when(fileConfiguration.getInt(anyString(), anyInt())).thenReturn(10);
+        when(fileConfiguration.getDouble(anyString(), anyDouble())).thenReturn(1.2);
+
+        skill = new TestBlockSkill(configService, log, playerRecordRepository, simpleSkills, messageService);
+
+        when(player.getGameMode()).thenReturn(GameMode.SURVIVAL);
+        when(player.getUniqueId()).thenReturn(UUID.fromString("11111111-1111-1111-1111-111111111111"));
+        when(playerRecordRepository.getPlayerRecord(any())).thenReturn(playerRecord);
+    }
+
+    @Test
+    public void handle_grantsExperienceAndReward_whenBlockWasNotPlayerPlaced() {
+        when(block.hasMetadata("simpleskills-player-placed")).thenReturn(false);
+        final BlockBreakEvent event = new BlockBreakEvent(block, player);
+
+        skill.handle(event);
+
+        verify(playerRecord).incrementExperience(anyInt());
+        assertTrue(skill.rewardExecuted);
+    }
+
+    @Test
+    public void handle_skipsExperienceAndReward_whenBlockWasPlayerPlaced() {
+        when(block.hasMetadata("simpleskills-player-placed")).thenReturn(true);
+        final BlockBreakEvent event = new BlockBreakEvent(block, player);
+
+        skill.handle(event);
+
+        verify(playerRecord, never()).incrementExperience(anyInt());
+        assertFalse(skill.rewardExecuted);
+    }
+
+    /**
+     * Minimal concrete {@link AbstractBlockSkill} that always matches, so tests exercise
+     * only the player-placed-block check rather than any single real skill's own filtering.
+     */
+    private static class TestBlockSkill extends AbstractBlockSkill {
+        boolean rewardExecuted = false;
+
+        TestBlockSkill(ConfigService configService, Log log, PlayerRecordRepository playerRecordRepository,
+                        SimpleSkills simpleSkills, MessageService messageService) {
+            super(configService, log, playerRecordRepository, simpleSkills, messageService, "TestBlock");
+        }
+
+        @Override
+        public boolean isRequiredItem(@NotNull ItemStack item, @NotNull Block targetBlock, @NotNull String context) {
+            return true;
+        }
+
+        @Override
+        public boolean isItemRequired() {
+            return false;
+        }
+
+        @Override
+        public @NotNull BlockSkillType getBlockSkillType() {
+            return BlockSkillType.BREAK_SPECIFIC;
+        }
+
+        @Override
+        public boolean isValidMaterial(@NotNull Material material) {
+            return true;
+        }
+
+        @Override
+        public double getChance() {
+            return 0;
+        }
+
+        @Override
+        public boolean randomExpGainChance() {
+            return false;
+        }
+
+        @Override
+        public void executeReward(@NotNull Player player, Object... skillData) {
+            rewardExecuted = true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Players could Silk Touch-harvest a skill-tracked block (ore for Mining/Quarrying, logs for Woodcutting, etc.), place it back down, and re-break it repeatedly for unlimited skill experience, since `AbstractBlockSkill` granted experience/rewards for any matching block regardless of whether a natural block generated it or a player placed it.
- Adds `PlacedBlockListener`, a global listener that tags any block a player places with block metadata (`Block#setMetadata`/`hasMetadata`, which works on all block types even on this project's pinned 1.18.1 API — unlike `PersistentDataContainer`, which wasn't available on non-tile-entity blocks until later API versions) and cleans the tag up when the block is later broken.
- `AbstractBlockSkill.handle(BlockBreakEvent)` now checks `PlacedBlockListener.isPlayerPlaced(block)` and skips `incrementExperience`/`executeReward` for player-placed blocks. This applies uniformly to every `AbstractBlockSkill` subclass (Mining, Quarrying, Digging, Woodcutting, Floriculture, Pyromaniac), not just Mining, since they all share the same exploit surface.
- `PlacedBlockListener` is registered *after* the skills in `SimpleSkills#registerEventListeners()` — both it and the skills use `MONITOR` priority, and Bukkit fires same-priority handlers in registration order, so the skills see the tracking metadata before `PlacedBlockListener`'s own `BlockBreakEvent` handler removes it (bounding the metadata store to only currently-placed-and-unbroken blocks).

## Test plan
- [x] `mvn test` — all 24 tests pass (20 pre-existing + 4 new).
- [x] New `PlacedBlockListenerTest` covers marking on place, cleanup on break, and the `isPlayerPlaced` query — constructed via the real `BlockPlaceEvent`/`BlockBreakEvent` constructors (not mocked) since `BlockEvent#getBlock()` is `final` and can't be stubbed with this project's pinned mockito-core.
- [x] New `AbstractBlockSkillTest` exercises `handle(BlockBreakEvent)` end-to-end via a minimal concrete test double, confirming experience/reward are granted for a natural block and skipped for a player-placed one.
- [x] Regression check: reverted the `AbstractBlockSkill` guard locally and re-ran `AbstractBlockSkillTest#handle_skipsExperienceAndReward_whenBlockWasPlayerPlaced` — it failed (experience was granted) as expected, then passed again once the guard was restored.
- [ ] Manual `.testcontainer` Spigot smoke test — not run this cycle (no live server available); the unit tests above are the coverage for this change. Flagging as UNVERIFIED for the actual runtime metadata/event-priority interaction, since that can only be fully confirmed on a live server.

Closes #73

---

_drafted by Claude on behalf of Daniel Stephenson_