### PR TITLE
Fix IllegalArgumentException from Crafting skill on unresolved recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Broken `Ponder` dependency coordinates in `pom.xml` that made the project (and CI) fail to build: the pinned tag `v0.14-alpha-2` no longer exists upstream, and the `groupId`/`artifactId` combination was never resolvable via jitpack for this repository
 - Silk Touch mining/quarrying/digging/woodcutting/floriculture/pyromaniac experience farming exploit: breaking a block that a player placed (e.g. a Silk Touch-harvested ore placed back down) no longer grants skill experience or rewards
+- `IllegalArgumentException` thrown (and logged to console) by the Crafting skill's reward handler when `CraftItemEvent#getRecipe()` reports no recipe (e.g. certain merge/repair crafts); the reward is now skipped instead
 
 ## [2.4.1]
 

--- a/src/main/java/dansplugins/simpleskills/skill/skills/Crafting.java
+++ b/src/main/java/dansplugins/simpleskills/skill/skills/Crafting.java
@@ -85,7 +85,9 @@ public class Crafting extends AbstractSkill {
         if (!isBenefitEnabled()) return;
         if (skillData.length != 1) throw new IllegalArgumentException("Skill Data is not of length '1'");
         final Object createdData = skillData[0];
-        if (!(createdData instanceof Recipe)) throw new IllegalArgumentException("SkillData[0] is not Recipe");
+        // CraftItemEvent#getRecipe() can legitimately return null (e.g. certain merge/repair
+        // crafts), so this is skipped rather than treated as a programmer error.
+        if (!(createdData instanceof Recipe)) return;
         final Recipe created = (Recipe) createdData;
         if (!(created instanceof ShapedRecipe) && !(created instanceof ShapelessRecipe)) return;
         if (!chanceCalculator.roll(record, this, 0.10)) return;

--- a/src/test/java/dansplugins/simpleskills/skill/skills/CraftingTest.java
+++ b/src/test/java/dansplugins/simpleskills/skill/skills/CraftingTest.java
@@ -1,0 +1,90 @@
+package dansplugins.simpleskills.skill.skills;
+
+import dansplugins.simpleskills.SimpleSkills;
+import dansplugins.simpleskills.chance.ChanceCalculator;
+import dansplugins.simpleskills.config.ConfigService;
+import dansplugins.simpleskills.logging.Log;
+import dansplugins.simpleskills.message.MessageService;
+import dansplugins.simpleskills.playerrecord.PlayerRecord;
+import dansplugins.simpleskills.playerrecord.PlayerRecordRepository;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.PlayerInventory;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Characterizes {@link Crafting#executeReward(Player, Object...)}'s handling of a
+ * craft with no formed recipe, which {@code CraftItemEvent#getRecipe()} can legitimately
+ * report (e.g. certain merge/repair crafts) and previously threw an {@link IllegalArgumentException}.
+ */
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class CraftingTest {
+
+    @Mock
+    private ConfigService configService;
+    @Mock
+    private Log log;
+    @Mock
+    private PlayerRecordRepository playerRecordRepository;
+    @Mock
+    private SimpleSkills simpleSkills;
+    @Mock
+    private MessageService messageService;
+    @Mock
+    private ChanceCalculator chanceCalculator;
+    @Mock
+    private FileConfiguration fileConfiguration;
+    @Mock
+    private Player player;
+    @Mock
+    private PlayerInventory playerInventory;
+    @Mock
+    private PlayerRecord playerRecord;
+
+    private Crafting crafting;
+
+    @Before
+    public void setUp() {
+        when(configService.getConfig()).thenReturn(fileConfiguration);
+        when(fileConfiguration.getBoolean(anyString(), anyBoolean())).thenReturn(true);
+        when(fileConfiguration.getInt(anyString(), anyInt())).thenReturn(10);
+        when(fileConfiguration.getDouble(anyString(), anyDouble())).thenReturn(1.2);
+
+        crafting = new Crafting(configService, log, playerRecordRepository, simpleSkills, messageService, chanceCalculator);
+
+        when(player.getUniqueId()).thenReturn(UUID.fromString("11111111-1111-1111-1111-111111111111"));
+        when(player.getInventory()).thenReturn(playerInventory);
+        when(playerRecordRepository.getPlayerRecord(any())).thenReturn(playerRecord);
+    }
+
+    @Test
+    public void executeReward_skipsReward_whenRecipeIsNull() {
+        crafting.executeReward(player, (Object) null);
+
+        verify(chanceCalculator, never()).roll(any(), any(), anyDouble());
+        verify(playerInventory, never()).addItem(any());
+    }
+
+    @Test
+    public void executeReward_skipsReward_whenSkillDataIsNotARecipe() {
+        crafting.executeReward(player, "not a recipe");
+
+        verify(chanceCalculator, never()).roll(any(), any(), anyDouble());
+        verify(playerInventory, never()).addItem(any());
+    }
+}


### PR DESCRIPTION
## Summary

- An `IllegalArgumentException` ("SkillData[0] is not Recipe") raised by `Crafting#executeReward` is fixed. `CraftItemEvent#getRecipe()` can legitimately return `null` for some crafts (e.g. certain merge/repair recipes), and that case was previously treated as a programmer error rather than a normal, skippable craft. The reward is now skipped silently instead of throwing, matching the intermittent console error described in #105.
- A regression test (`CraftingTest`) is added, covering both a `null` recipe and a non-`Recipe` value being passed as skill data. The test was confirmed to fail against the pre-fix code (stash-and-run) and pass with the fix restored.
- A `CHANGELOG.md` entry is added under `[Unreleased] > Fixed`.

## Separately investigated, not included in this PR

Issue #116 ("Update Ponder dependency to latest release") was examined during triage. The latest upstream `Ponder` release was found to be a full rewrite (Gradle multi-module, Kotlin, package `preponderous.ponder.*`) that no longer exposes the classes this plugin currently depends on (`AbstractPluginCommand`, `NMSAssistant`, `PonderMC`, `UUIDChecker`, `Cacheable`, `Savable`, `JsonWriterReader`). A version bump would therefore require a substantial migration rather than a small dependency update, so it was left out of scope for this cycle; a finding was left on the issue for a dedicated follow-up.

## Test plan

- [x] `mvn test` — all 26 tests pass
- [x] New `CraftingTest` tests confirmed to fail without the fix and pass with it (stash-and-run)

Closes #105

<!-- gardener-tend-dispatch -->

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).