### PR TITLE
Fall back to bundled message.yml when an on-disk message key is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Unit tests for `PlayerRecord` (skill levels, experience, overall level, save/load) and `ExperienceCalculator`
+- Unit tests for `MessageService` (bundled-default fallback, on-disk overrides, saving) and `AbstractSkill` trigger failure reporting
 
 ### Fixed
 - Broken `Ponder` dependency coordinates in `pom.xml` that made the project (and CI) fail to build: the pinned tag `v0.14-alpha-2` no longer exists upstream, and the `groupId`/`artifactId` combination was never resolvable via jitpack for this repository
 - Silk Touch mining/quarrying/digging/woodcutting/floriculture/pyromaniac experience farming exploit: breaking a block that a player placed (e.g. a Silk Touch-harvested ore placed back down) no longer grants skill experience or rewards
 - `IllegalArgumentException` thrown (and logged to console) by the Crafting skill's reward handler when `CraftItemEvent#getRecipe()` reports no recipe (e.g. certain merge/repair crafts); the reward is now skipped instead
+- `IllegalStateException: Failed to trigger '<skill>' with event '<event>'!` raised on servers whose `message.yml` predates a message key the plugin now uses (the file on disk is never rewritten on upgrade): message lookups now fall back to the copy of `message.yml` bundled in the jar, while any value present on disk still takes precedence
+
+### Changed
+- `IllegalStateException` reported when a skill trigger fails now carries the underlying failure as its cause, and the failure is logged through the plugin logger instead of a bare stack trace
 
 ## [2.4.1]
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -135,6 +135,8 @@ Skills can also be toggled at runtime using the admin commands `/ss force activa
 
 The `message.yml` file is located in `plugins/SimpleSkills/message.yml` on your server. It controls all user-facing messages displayed by the plugin.
 
+An existing `message.yml` is never overwritten when the plugin is updated, so a file written by an older version can be missing keys that a newer version uses. Any such key falls back to the value bundled with the plugin; keys present in the file on disk always take precedence, so customised messages are kept.
+
 ### `message-version`
 
 **Type:** String  

--- a/src/main/java/dansplugins/simpleskills/message/MessageService.java
+++ b/src/main/java/dansplugins/simpleskills/message/MessageService.java
@@ -7,8 +7,14 @@ import org.bukkit.configuration.file.YamlConfiguration;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 
 public class MessageService {
+    private static final String LANG_FILE_NAME = "message.yml";
+
     private final SimpleSkills simpleSkills;
 
     private File langFile;
@@ -19,9 +25,9 @@ public class MessageService {
     }
 
     public void createlang() {
-        langFile = new File(simpleSkills.getDataFolder(), "message.yml");
+        langFile = resolveLangFile();
 
-        if (!langFile.exists()) simpleSkills.saveResource("message.yml", false);
+        if (!langFile.exists()) simpleSkills.saveResource(LANG_FILE_NAME, false);
         lang = new YamlConfiguration();
 
         try {
@@ -29,6 +35,8 @@ public class MessageService {
         } catch (IOException | InvalidConfigurationException e) {
             e.printStackTrace();
         }
+
+        applyBundledDefaults();
     }
 
     public FileConfiguration getlang() {
@@ -38,6 +46,50 @@ public class MessageService {
 
     public void reloadlang() {
         lang = YamlConfiguration.loadConfiguration(langFile);
+        applyBundledDefaults();
+    }
+
+    /**
+     * Method to obtain the message file within the plugin's data folder.
+     * <p>
+     * The lookup is isolated here so that it can be overridden with a temporary file in tests,
+     * as {@link org.bukkit.plugin.java.JavaPlugin#getDataFolder()} is final and cannot be mocked.
+     * </p>
+     *
+     * @return the message file on disk.
+     */
+    File resolveLangFile() {
+        return new File(simpleSkills.getDataFolder(), LANG_FILE_NAME);
+    }
+
+    /**
+     * Method to obtain the message file bundled in the plugin jar.
+     *
+     * @return a stream over the bundled message file, or {@code null} if it isn't on the classpath.
+     */
+    InputStream openBundledLang() {
+        return getClass().getClassLoader().getResourceAsStream(LANG_FILE_NAME);
+    }
+
+    /**
+     * Method to back the loaded message file with the message file bundled in the plugin jar.
+     * <p>
+     * A message.yml written to disk by an older version of the plugin is never rewritten on
+     * upgrade, so any message key introduced afterwards is absent from it and is looked up as
+     * {@code null}. Callers wrap those lookups in {@link java.util.Objects#requireNonNull},
+     * so a missing key throws inside a skill trigger and the whole event handler fails.
+     * Registering the bundled file as the defaults makes such a key fall back to its shipped
+     * value instead. Values present on disk still win, so player customisations are preserved,
+     * and the defaults are not written back to disk by {@link #savelang()}.
+     * </p>
+     */
+    private void applyBundledDefaults() {
+        final InputStream bundledLang = openBundledLang();
+        if (bundledLang == null) return;
+        try (Reader reader = new InputStreamReader(bundledLang, StandardCharsets.UTF_8)) {
+            lang.setDefaults(YamlConfiguration.loadConfiguration(reader));
+        } catch (IOException ignored) {
+        }
     }
 
     public void savelang() {

--- a/src/main/java/dansplugins/simpleskills/skill/abs/AbstractSkill.java
+++ b/src/main/java/dansplugins/simpleskills/skill/abs/AbstractSkill.java
@@ -139,9 +139,13 @@ public abstract class AbstractSkill implements Listener {
             try {
                 method.invoke(this, event);
             } catch (IllegalAccessException | InvocationTargetException exception) {
-                exception.printStackTrace();
+                // The reflective wrapper hides what actually went wrong, so the underlying
+                // failure is both logged and attached as the cause of the rethrown exception.
+                final Throwable cause = exception.getCause() == null ? exception : exception.getCause();
+                log.error("Failed to trigger '" + name + "' with event '" + event.getEventName() +
+                        "' due to " + cause);
                 throw new IllegalStateException("Failed to trigger '" + name + "' with event '" +
-                        event.getEventName() + "'!");
+                        event.getEventName() + "'!", cause);
             }
         }
     }

--- a/src/test/java/dansplugins/simpleskills/message/MessageServiceTest.java
+++ b/src/test/java/dansplugins/simpleskills/message/MessageServiceTest.java
@@ -1,0 +1,160 @@
+package dansplugins.simpleskills.message;
+
+import dansplugins.simpleskills.SimpleSkills;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Characterizes {@link MessageService}'s handling of a message.yml written to disk by an
+ * older version of the plugin: keys added afterwards are absent from it, and skills look
+ * them up through {@code Objects.requireNonNull}, so a null lookup previously failed the
+ * whole event handler that reached it.
+ */
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class MessageServiceTest {
+
+    /**
+     * The message file bundled in the plugin jar, holding a key the on-disk file predates.
+     */
+    private static final String BUNDLED_LANG = String.join("\n",
+            "message-version: 0.2",
+            "Help-Command:",
+            "  - \"&9/ss help - bundled\"",
+            "Skills:",
+            "  Quarrying:",
+            "    DoubleDrop: \"&bbundled double drop\"",
+            "    Exp: \"&bYou found &a%exp%&b experience while quarrying!\"");
+
+    /**
+     * The message file an older version of the plugin left on disk: no Quarrying Exp key, and
+     * a customised double drop message.
+     */
+    private static final String OUTDATED_ON_DISK_LANG = String.join("\n",
+            "message-version: 0.1",
+            "Skills:",
+            "  Quarrying:",
+            "    DoubleDrop: \"&bcustomised double drop\"");
+
+    @Rule
+    public TemporaryFolder dataFolder = new TemporaryFolder();
+
+    @Mock
+    private SimpleSkills simpleSkills;
+
+    private TestMessageService messageService;
+
+    @Before
+    public void setUp() throws IOException {
+        writeOnDiskLang(OUTDATED_ON_DISK_LANG);
+        messageService = new TestMessageService(simpleSkills, onDiskLang());
+    }
+
+    @Test
+    public void createlang_fallsBackToBundledValue_whenOnDiskFileIsMissingTheKey() {
+        messageService.createlang();
+
+        assertEquals("&bYou found &a%exp%&b experience while quarrying!",
+                messageService.getlang().getString("Skills.Quarrying.Exp"));
+    }
+
+    @Test
+    public void createlang_fallsBackToBundledList_whenOnDiskFileIsMissingTheKey() {
+        messageService.createlang();
+
+        assertEquals(Collections.singletonList("&9/ss help - bundled"),
+                messageService.getlang().getStringList("Help-Command"));
+    }
+
+    @Test
+    public void createlang_keepsOnDiskValue_whenTheKeyIsPresent() {
+        messageService.createlang();
+
+        assertEquals("&bcustomised double drop",
+                messageService.getlang().getString("Skills.Quarrying.DoubleDrop"));
+    }
+
+    @Test
+    public void createlang_leavesTheKeyMissing_whenTheJarHasNoBundledMessageFile() {
+        messageService.bundledLang = null;
+
+        messageService.createlang();
+
+        assertNull(messageService.getlang().getString("Skills.Quarrying.Exp"));
+    }
+
+    @Test
+    public void reloadlang_fallsBackToBundledValue_whenOnDiskFileIsMissingTheKey() {
+        messageService.createlang();
+
+        messageService.reloadlang();
+
+        assertEquals("&bYou found &a%exp%&b experience while quarrying!",
+                messageService.getlang().getString("Skills.Quarrying.Exp"));
+    }
+
+    @Test
+    public void savelang_doesNotWriteBundledDefaultsToDisk() throws IOException {
+        messageService.createlang();
+
+        messageService.savelang();
+
+        assertNull(YamlConfiguration.loadConfiguration(onDiskLang()).getString("Skills.Quarrying.Exp"));
+        assertFalse(readOnDiskLang().contains("experience while quarrying"));
+    }
+
+    private void writeOnDiskLang(String contents) throws IOException {
+        Files.write(onDiskLang().toPath(), contents.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private String readOnDiskLang() throws IOException {
+        return new String(Files.readAllBytes(onDiskLang().toPath()), StandardCharsets.UTF_8);
+    }
+
+    private File onDiskLang() {
+        return new File(dataFolder.getRoot(), "message.yml");
+    }
+
+    /**
+     * {@link MessageService} reading a temporary message file and a fixed bundled message file,
+     * since {@link org.bukkit.plugin.java.JavaPlugin}'s data folder and resource lookups cannot
+     * be mocked.
+     */
+    private static class TestMessageService extends MessageService {
+        private final File langFile;
+        private String bundledLang = BUNDLED_LANG;
+
+        TestMessageService(SimpleSkills simpleSkills, File langFile) {
+            super(simpleSkills);
+            this.langFile = langFile;
+        }
+
+        @Override
+        File resolveLangFile() {
+            return langFile;
+        }
+
+        @Override
+        InputStream openBundledLang() {
+            if (bundledLang == null) return null;
+            return new ByteArrayInputStream(bundledLang.getBytes(StandardCharsets.UTF_8));
+        }
+    }
+}

--- a/src/test/java/dansplugins/simpleskills/skill/abs/AbstractSkillTest.java
+++ b/src/test/java/dansplugins/simpleskills/skill/abs/AbstractSkillTest.java
@@ -65,7 +65,7 @@ public class AbstractSkillTest {
     @Test
     public void handle_carriesTheUnderlyingFailureAsTheCause_whenATriggerThrows() {
         try {
-            skill.handle((org.bukkit.event.Event) new BlockBreakEvent(block, player));
+            skill.handle(new BlockBreakEvent(block, player));
             fail("Expected the failing trigger to be reported as an IllegalStateException");
         } catch (IllegalStateException exception) {
             assertEquals("Failed to trigger 'Throwing' with event 'BlockBreakEvent'!", exception.getMessage());

--- a/src/test/java/dansplugins/simpleskills/skill/abs/AbstractSkillTest.java
+++ b/src/test/java/dansplugins/simpleskills/skill/abs/AbstractSkillTest.java
@@ -1,0 +1,107 @@
+package dansplugins.simpleskills.skill.abs;
+
+import dansplugins.simpleskills.SimpleSkills;
+import dansplugins.simpleskills.config.ConfigService;
+import dansplugins.simpleskills.logging.Log;
+import dansplugins.simpleskills.message.MessageService;
+import dansplugins.simpleskills.playerrecord.PlayerRecordRepository;
+import org.bukkit.block.Block;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * Characterizes {@link AbstractSkill#handle(org.bukkit.event.Event)}'s reporting of a trigger
+ * failure, which is raised through reflection and therefore hides the real failure unless the
+ * cause is carried over to the rethrown exception.
+ */
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class AbstractSkillTest {
+
+    @Mock
+    private ConfigService configService;
+    @Mock
+    private Log log;
+    @Mock
+    private PlayerRecordRepository playerRecordRepository;
+    @Mock
+    private SimpleSkills simpleSkills;
+    @Mock
+    private MessageService messageService;
+    @Mock
+    private FileConfiguration fileConfiguration;
+    @Mock
+    private Player player;
+    @Mock
+    private Block block;
+
+    private ThrowingSkill skill;
+
+    @Before
+    public void setUp() {
+        when(configService.getConfig()).thenReturn(fileConfiguration);
+        when(fileConfiguration.getBoolean(anyString(), anyBoolean())).thenReturn(true);
+        when(fileConfiguration.getInt(anyString(), anyInt())).thenReturn(10);
+        when(fileConfiguration.getDouble(anyString(), anyDouble())).thenReturn(1.2);
+
+        skill = new ThrowingSkill(configService, log, playerRecordRepository, simpleSkills, messageService);
+    }
+
+    @Test
+    public void handle_carriesTheUnderlyingFailureAsTheCause_whenATriggerThrows() {
+        try {
+            skill.handle((org.bukkit.event.Event) new BlockBreakEvent(block, player));
+            fail("Expected the failing trigger to be reported as an IllegalStateException");
+        } catch (IllegalStateException exception) {
+            assertEquals("Failed to trigger 'Throwing' with event 'BlockBreakEvent'!", exception.getMessage());
+            assertSame(skill.thrown, exception.getCause());
+        }
+    }
+
+    /**
+     * Minimal concrete {@link AbstractSkill} whose only trigger fails, standing in for any
+     * skill whose reward path throws (for example on a message key its message.yml predates).
+     */
+    public static class ThrowingSkill extends AbstractSkill {
+        final RuntimeException thrown = new NullPointerException("missing message key");
+
+        ThrowingSkill(ConfigService configService, Log log, PlayerRecordRepository playerRecordRepository,
+                      SimpleSkills simpleSkills, MessageService messageService) {
+            super(configService, log, playerRecordRepository, simpleSkills, messageService, "Throwing",
+                    BlockBreakEvent.class);
+        }
+
+        public void handleBlockBreak(BlockBreakEvent event) {
+            throw thrown;
+        }
+
+        @Override
+        public double getChance() {
+            return 0;
+        }
+
+        @Override
+        public boolean randomExpGainChance() {
+            return false;
+        }
+
+        @Override
+        public void executeReward(@NotNull Player player, Object... skillData) {
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **Root cause of #134.** An existing `plugins/SimpleSkills/message.yml` is never rewritten when the plugin is updated (`MessageService#createlang` only writes the resource when the file is absent), so a file written by an older version lacks every message key introduced afterwards. `Skills.Quarrying.Exp` was added by PR #123 (merged 2025-12-11); #134 was reported against v2.3.0-alpha-1 on 2026-01-02, which is the upgrade case. Every skill reads its messages through `Objects.requireNonNull(messageService.getlang().getString(...))`, so an absent key throws inside `Method#invoke` in `AbstractSkill#handle`, which rethrows it as `IllegalStateException: Failed to trigger 'Quarrying' with event 'BlockBreakEvent'!` — exactly the reported stack trace. The startup check in `SimpleSkills#checkFilesVersion` only logs a warning about an outdated `message.yml`; it does not prevent the failure.
- **Fix.** `MessageService` now registers the `message.yml` bundled in the jar as the defaults of the loaded configuration, in both `createlang()` and `reloadlang()`. A key missing from disk resolves to its shipped value instead of `null`; a key present on disk still wins, so customised messages are preserved; and the defaults are not written back to disk by `savelang()`, so the operator's file is left untouched. The fix covers every message key in every skill, not just the Quarrying one that was reported.
- **Diagnosability.** `AbstractSkill#handle` now attaches the underlying failure as the cause of the rethrown `IllegalStateException` and logs it through the plugin logger instead of a bare `printStackTrace()`. Should any comparable trigger failure remain, the console will name the real exception rather than only the reflective wrapper.
- **Testability seams.** `resolveLangFile()` and `openBundledLang()` were extracted as package-private methods because `JavaPlugin#getDataFolder()` is final and cannot be mocked; production behaviour is unchanged.

## Test plan

- [x] `mvn clean package` — 33 tests, 0 failures, 0 errors (27 before this change)
- [x] New `MessageServiceTest` (6 tests): bundled-default fallback for a string key and a list key, on-disk value taking precedence, no bundled file leaving the key absent, fallback after `reloadlang()`, and `savelang()` not writing defaults to disk
- [x] New `AbstractSkillTest` (1 test): a failing trigger is reported with the underlying failure as the cause
- [x] Regression evidence, `MessageService`: with the two `applyBundledDefaults()` calls removed, the three fallback tests fail with `expected:<...> but was:<null>` — the same `null` that produced the reported crash — and pass once restored. The other three tests pass either way by design, as they guard against over-reach.
- [x] Regression evidence, `AbstractSkill`: with the file stashed, `handle_carriesTheUnderlyingFailureAsTheCause_whenATriggerThrows` fails with `expected same:<java.lang.NullPointerException: missing message key> was not:<null>`, and passes once restored.
- [ ] Not verified on a live server: the `.testcontainer` Docker smoke harness is not part of CI and was not run, so the in-game upgrade path (old `message.yml` plus new jar) rests on the unit tests above rather than on observed server behaviour.

## Documentation

`CHANGELOG.md` records the fix and the changed error reporting. `CONFIG.md`'s `message.yml` section documents the new fallback and the precedence rule. No command, permission node, or config key was added, changed, or removed, so `HelpCommand.java`, `COMMANDS.md`, and `USER_GUIDE.md` are unaffected.

## Deferred this cycle

The remaining open issues were not selected, for the reasons below:

| Issue | Reason for deferral |
|---|---|
| #140, #129, #128, #124, #119, #112 | An open draft PR already exists for each (#141, #130, #131, #132, #120, #118 respectively); duplicating that work would conflict with it |
| #127 | Rebalancing the experience curve changes every existing player's progression and warrants a maintainer decision on the target curve before implementation |
| #116 | Updating the Ponder dependency needs the upgrade verified against a running server, which the unit suite cannot cover |
| #109, #87 | Persistence on server save and on crash overlap and need a design decision on save granularity; PR #115 already added a five-minute autosave, so the residual scope is unclear |
| #97, #88, #86, #90, #89, #77 | Feature requests larger than a single polish-sized PR |

Two issues were closed during triage as already implemented and merged: #121 (by PR #123) and #122 (by PR #133).

## Notes

Closes #134

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

<!-- gardener-tend-dispatch -->