### PR TITLE
chore: release version 3.0.0-SNAPSHOT-8-8-2026

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased]
+## [3.0.0-SNAPSHOT-8-8-2026] – 2026-08-08
+
+### Changed
+- SimpleSkills is now developed AI-first. Day-to-day feature work, grooming, review and maintenance run through AI agents working directly against this repository, with the maintainers setting direction and approving what lands. The major version bump marks that change in how the project is built — it is not a break in behaviour, configuration or stored data, and existing installations can upgrade in place. Released as `3.0.0-SNAPSHOT-8-8-2026`: the AI-first line has not yet been verified in live operation, and the dated snapshot designation stays until it has.
 
 ### Added
 - Unit tests for `PlayerRecord` (skill levels, experience, overall level, save/load) and `ExperienceCalculator`

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dansplugins</groupId>
     <artifactId>SimpleSkills</artifactId>
-    <version>2.4.1</version>
+    <version>3.0.0-SNAPSHOT-8-8-2026</version>
     <packaging>jar</packaging>
 
     <name>SimpleSkills</name>


### PR DESCRIPTION
## Summary

The version has been bumped from `2.4.1` to `3.0.0-SNAPSHOT-8-8-2026` in `pom.xml`.

The bump marks SimpleSkills moving to an AI-first development approach: day-to-day feature work,
grooming, review and maintenance now run through AI agents working directly against this
repository, with the maintainers setting direction and approving what lands.

It is not a compatibility break. Behaviour, configuration and stored data are unchanged, and
existing installations can upgrade in place — the version marks a change in how the project is
built, not in what it does.

## Snapshot designation

The dated snapshot designation follows the precedent set by Medieval Factions'
`6.0.0-SNAPSHOT-7-25-2026`: the AI-first line has not yet been verified in live operation, and
the designation stays until it has.

## Notes

This is part of a garden-wide pass applying the same bump across every project tended by
Gardener. Only version metadata has been changed; no functional code was touched.

---
*Drafted by Claude on behalf of Daniel Stephenson.*
