### PR TITLE
Stop skills from retaining every event they handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - A `Dev Release` workflow, which republishes a rolling `dev` prerelease of `main` on every non-documentation push. This is what Dan's Plugin Manager's experimental channel installs from: `/dpm get simpleskills --experimental` reads `releases/tags/dev`, so without it there is nothing for that command to download. The prerelease is unreleased, unreviewed code and is marked as such.
 
+### Fixed
+
+- Growing memory use on long-running servers: every skill kept a reference to every event it had ever handled — and, through it, to that event's block, player and entities — for as long as the server ran. The events were remembered only so that a skill would not act on the same one twice, which is now prevented where the duplicate arose instead, by each skill listening only for the events its triggers accept and each listener taking only the event class it was registered for.
+
 ## [3.0.0-SNAPSHOT-8-8-2026] – 2026-08-08
 
 ### Changed

--- a/src/main/java/dansplugins/simpleskills/skill/abs/AbstractSkill.java
+++ b/src/main/java/dansplugins/simpleskills/skill/abs/AbstractSkill.java
@@ -3,7 +3,6 @@ package dansplugins.simpleskills.skill.abs;
 import dansplugins.simpleskills.SimpleSkills;
 import dansplugins.simpleskills.playerrecord.PlayerRecordRepository;
 import dansplugins.simpleskills.playerrecord.PlayerRecord;
-import dansplugins.simpleskills.enums.Triggers;
 import dansplugins.simpleskills.config.ConfigService;
 
 import dansplugins.simpleskills.message.MessageService;
@@ -18,6 +17,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.plugin.EventExecutor;
+import org.bukkit.plugin.PluginManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -40,7 +40,6 @@ public abstract class AbstractSkill implements Listener {
     private final String name;
     private final String benefitConfigKey;  // Cached config key for benefit checking
     private final HashMap<Class<? extends Event>, List<Method>> handlers = new HashMap<>();
-    private final HashSet<Event> calledEvents = new HashSet<>();
     private int expReq;
     private double expFactor;
     private boolean active;
@@ -124,15 +123,19 @@ public abstract class AbstractSkill implements Listener {
      * <p>
      * This method references {@link #handlers} which is defined by {@link #setupTriggers(Class[])},
      * each method within the map is called if the event currently being handled by this method
-     * is compatible with the specific trigger.
+     * is compatible with the specific trigger. Dispatch is on the event's exact class, so an
+     * event only reaches a trigger method declared for that class.
+     * </p>
+     * <p>
+     * Delivering the same event to a skill more than once is prevented by {@link #register()},
+     * which forwards each registration only the class it was made for, rather than by this
+     * method remembering the events it has already seen.
      * </p>
      *
      * @param event to handle.
      */
     public void handle(Event event) {
         if (!active) return;
-        if (calledEvents.contains(event)) return;
-        calledEvents.add(event);
         if (event instanceof Cancellable) if (((Cancellable) event).isCancelled()) return;
         final List<Method> methods = handlers.getOrDefault(event.getClass(), new ArrayList<>());
         for (Method method : methods) {
@@ -264,22 +267,48 @@ public abstract class AbstractSkill implements Listener {
     }
 
     /**
-     * Method to dynamically register every listener defined in {@link Triggers}.
+     * Method to dynamically register a listener for every event this skill declares a trigger for.
      * <p>
      * This enables the "Skill" class to listen to multiple events for the
      * listener-trigger-hook system.
      * </p>
+     * <p>
+     * Only the classes in {@link #handlers} are registered: an event no trigger method accepts
+     * is discarded by {@link #handle(Event)} anyway, so registering for it costs a listener call
+     * per event for nothing.
+     * </p>
+     * <p>
+     * Each registration forwards only events of the exact class it was made for. Bukkit keys its
+     * handler lists on whichever class declares one, so a registration made for an event class
+     * that shares its handler list with a relative also receives that relative's events — without
+     * this filter a skill declaring triggers for both would see one event twice.
+     * </p>
      */
     public void register() {
         log.debug("Registering skill: " + getName());
-        final EventExecutor executor = (listener, event) -> handle(event);
-        for (Triggers value : Triggers.values()) {
-            log.debug("Registering trigger " + value.name());
-            Bukkit.getPluginManager().registerEvent(
-                    value.getTriggerClass(), this, EventPriority.MONITOR, executor, simpleSkills
+        for (Class<? extends Event> trigger : handlers.keySet()) {
+            log.debug("Registering trigger " + trigger.getSimpleName());
+            final EventExecutor executor = (listener, event) -> {
+                if (event.getClass() == trigger) handle(event);
+            };
+            getPluginManager().registerEvent(
+                    trigger, this, EventPriority.MONITOR, executor, simpleSkills
             );
-            log.debug("Registered trigger " + value.name() + " for skill " + getName());
+            log.debug("Registered trigger " + trigger.getSimpleName() + " for skill " + getName());
         }
+    }
+
+    /**
+     * Method to obtain the plugin manager the skill registers its listeners with.
+     * <p>
+     * {@link Bukkit#getPluginManager()} reads static server state that no unit test has a server
+     * to provide, so this indirection exists for tests to substitute a plugin manager.
+     * </p>
+     *
+     * @return the server's {@link PluginManager}.
+     */
+    PluginManager getPluginManager() {
+        return Bukkit.getPluginManager();
     }
 
     // Id-generation and equality overriding

--- a/src/test/java/dansplugins/simpleskills/skill/abs/AbstractSkillTest.java
+++ b/src/test/java/dansplugins/simpleskills/skill/abs/AbstractSkillTest.java
@@ -7,28 +7,47 @@ import dansplugins.simpleskills.message.MessageService;
 import dansplugins.simpleskills.playerrecord.PlayerRecordRepository;
 import org.bukkit.block.Block;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.event.EventException;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.plugin.EventExecutor;
+import org.bukkit.plugin.PluginManager;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.Map;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 /**
- * Characterizes {@link AbstractSkill#handle(org.bukkit.event.Event)}'s reporting of a trigger
- * failure, which is raised through reflection and therefore hides the real failure unless the
- * cause is carried over to the rethrown exception.
+ * Characterizes {@link AbstractSkill}'s event plumbing: the reporting of a trigger failure,
+ * which is raised through reflection and therefore hides the real failure unless the cause is
+ * carried over to the rethrown exception, and the listener registration, which decides both
+ * which events reach a skill and how many times each one does.
  */
 @RunWith(MockitoJUnitRunner.Silent.class)
 public class AbstractSkillTest {
@@ -49,8 +68,15 @@ public class AbstractSkillTest {
     private Player player;
     @Mock
     private Block block;
+    @Mock
+    private PluginManager pluginManager;
+    @Mock
+    private Entity damager;
+    @Mock
+    private Entity damagee;
 
     private ThrowingSkill skill;
+    private CountingSkill countingSkill;
 
     @Before
     public void setUp() {
@@ -60,6 +86,8 @@ public class AbstractSkillTest {
         when(fileConfiguration.getDouble(anyString(), anyDouble())).thenReturn(1.2);
 
         skill = new ThrowingSkill(configService, log, playerRecordRepository, simpleSkills, messageService);
+        countingSkill = new CountingSkill(configService, log, playerRecordRepository, simpleSkills, messageService,
+                pluginManager);
     }
 
     @Test
@@ -70,6 +98,112 @@ public class AbstractSkillTest {
         } catch (IllegalStateException exception) {
             assertEquals("Failed to trigger 'Throwing' with event 'BlockBreakEvent'!", exception.getMessage());
             assertSame(skill.thrown, exception.getCause());
+        }
+    }
+
+    @Test
+    public void handle_doesNotRetainTheEventItHandled() throws IllegalAccessException {
+        final BlockBreakEvent event = new BlockBreakEvent(block, player);
+
+        countingSkill.handle(event);
+
+        assertEquals(1, countingSkill.blockBreaks);
+        // A skill that remembers the events it has handled keeps every one of them — and
+        // everything each one references, such as a block and a player — alive for as long as
+        // the server runs, so no field of the skill may hold on to the event once it is handled.
+        for (Field field : AbstractSkill.class.getDeclaredFields()) {
+            field.setAccessible(true);
+            final Object value = field.get(countingSkill);
+            final String retained = "Field '" + field.getName() + "' retains the handled event";
+            if (value instanceof Collection) {
+                assertFalse(retained, ((Collection<?>) value).contains(event));
+            }
+            if (value instanceof Map) {
+                assertFalse(retained, ((Map<?, ?>) value).containsKey(event));
+                assertFalse(retained, ((Map<?, ?>) value).containsValue(event));
+            }
+        }
+    }
+
+    @Test
+    public void register_registersOnlyTheEventsTheSkillHasATriggerMethodFor() {
+        countingSkill.register();
+
+        verify(pluginManager).registerEvent(eq(BlockBreakEvent.class), eq(countingSkill),
+                eq(EventPriority.MONITOR), any(EventExecutor.class), eq(simpleSkills));
+        verify(pluginManager).registerEvent(eq(EntityDamageEvent.class), eq(countingSkill),
+                eq(EventPriority.MONITOR), any(EventExecutor.class), eq(simpleSkills));
+        verify(pluginManager).registerEvent(eq(EntityDamageByEntityEvent.class), eq(countingSkill),
+                eq(EventPriority.MONITOR), any(EventExecutor.class), eq(simpleSkills));
+        verifyNoMoreInteractions(pluginManager);
+    }
+
+    @Test
+    public void register_deliversAnEventToItsTriggerMethodOnlyOnce() throws EventException {
+        countingSkill.register();
+        final ArgumentCaptor<EventExecutor> executors = ArgumentCaptor.forClass(EventExecutor.class);
+        verify(pluginManager, times(3)).registerEvent(any(), any(), any(), executors.capture(), any());
+
+        // Bukkit keys its handler lists on whichever class declares one, so every registration
+        // this skill made for a class sharing a handler list receives the same event. Passing the
+        // event to all of them stands in for that delivery.
+        final EntityDamageByEntityEvent event = new EntityDamageByEntityEvent(damager, damagee,
+                EntityDamageEvent.DamageCause.ENTITY_ATTACK, 1.0);
+        for (EventExecutor executor : executors.getAllValues()) {
+            executor.execute(countingSkill, event);
+        }
+
+        assertEquals(1, countingSkill.attacks);
+        assertEquals("A trigger declared for a superclass of the event must not be called",
+                0, countingSkill.damages);
+    }
+
+    /**
+     * Minimal concrete {@link AbstractSkill} counting the events its triggers receive, standing in
+     * for any skill declaring triggers for event classes that share a handler list.
+     */
+    public static class CountingSkill extends AbstractSkill {
+        final PluginManager pluginManager;
+        int blockBreaks;
+        int damages;
+        int attacks;
+
+        CountingSkill(ConfigService configService, Log log, PlayerRecordRepository playerRecordRepository,
+                      SimpleSkills simpleSkills, MessageService messageService, PluginManager pluginManager) {
+            super(configService, log, playerRecordRepository, simpleSkills, messageService, "Counting",
+                    BlockBreakEvent.class, EntityDamageEvent.class, EntityDamageByEntityEvent.class);
+            this.pluginManager = pluginManager;
+        }
+
+        public void handleBlockBreak(BlockBreakEvent event) {
+            blockBreaks++;
+        }
+
+        public void handleDamage(EntityDamageEvent event) {
+            damages++;
+        }
+
+        public void handleAttack(EntityDamageByEntityEvent event) {
+            attacks++;
+        }
+
+        @Override
+        PluginManager getPluginManager() {
+            return pluginManager;
+        }
+
+        @Override
+        public double getChance() {
+            return 0;
+        }
+
+        @Override
+        public boolean randomExpGainChance() {
+            return false;
+        }
+
+        @Override
+        public void executeReward(@NotNull Player player, Object... skillData) {
         }
     }
 


### PR DESCRIPTION
Every skill kept a `HashSet` of every event it had ever handled, and nothing ever removed an entry, so each handled event — and the block, player and entities it references — stayed reachable for as long as the server ran.

The set existed only to stop a skill acting twice on one event. That duplicate is now prevented where it originated, so the memo is no longer needed and has been removed.

## What changed

- **A skill now listens only for the events its trigger methods accept.** `register()` previously registered a listener for all twelve values of `Triggers` for every skill, even though `handle(Event)` discards an event no trigger method accepts. Registration is now driven by the trigger methods found on the class, which for the skills in this repository is between one and three listeners each instead of twelve.
- **Each listener forwards only events of the exact class it was registered for.** Bukkit keys its handler lists on whichever class declares one, so a registration made for an event class that shares its handler list with a relative also receives that relative's events; a skill declaring triggers for both therefore saw one event twice. Dispatch in `handle(Event)` was already on the event's exact class, so the filter changes nothing about which trigger method runs.
- **The `calledEvents` set is gone**, along with the retention it caused.
- A package-private `getPluginManager()` seam was added, because `Bukkit.getPluginManager()` reads static server state that a unit test has no server to provide.

The event classes named by the skills' constructors are exactly the twelve values of `Triggers`, so no skill loses a listener it was relying on.

## Test plan

- [x] `mvn test` — 36 tests, all passing (33 before, 3 added)
- [x] Regression evidence: with the previous behaviour reinstated locally, all three added tests fail (`Field 'calledEvents' retains the handled event`, plus the two registration assertions), and pass once the change is restored
- [x] Added `handle_doesNotRetainTheEventItHandled`, which asserts that no field of the skill holds the event after it has been handled
- [x] Added `register_registersOnlyTheEventsTheSkillHasATriggerMethodFor` and `register_deliversAnEventToItsTriggerMethodOnlyOnce`
- [ ] Not covered by any automated test: behaviour on a live server. The retention is observable only as heap growth over a long session, and the `.testcontainer` Spigot harness is not run in CI and was not run here. A smoke test on a real server is worth doing before this reaches users.

## Documentation

No command, permission node or configuration key changes, so `HelpCommand.java`, `COMMANDS.md`, `USER_GUIDE.md` and `CONFIG.md` are unaffected. A `Fixed` entry has been added to `CHANGELOG.md` under `[Unreleased]`.

## Issues deferred this cycle

The remaining open issues were left untouched: #87, #109, #97, #127 and #88 are feature or persistence work larger than one polish-sized change; #128, #129, #124, #112, #119 and #140 already have a draft pull request open against them (#131, #130, #132, #118, #120, #141); #116 changes `pom.xml`, which is on this loop's do-not-auto-merge list and is better handled where a human can approve the dependency bump; #77, #86, #89 and #90 are feature requests.

Closes #149

<!-- gardener-tend-dispatch -->

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

---

_drafted by Claude on behalf of Daniel Stephenson_
